### PR TITLE
Fix: Update deployment framework to static

### DIFF
--- a/windsurf_deployment.yaml
+++ b/windsurf_deployment.yaml
@@ -3,4 +3,4 @@
 # The ID of the project (different from project name) on the provider's system. This is populated as a way to update existing deployments.
 project_id: 59cecacd-db09-42ec-8b54-0cc0962cfdf8
 # The framework of the web application (examples: nextjs, react, vue, etc.)
-framework: hexo
+framework: static


### PR DESCRIPTION
The project was incorrectly configured to use 'hexo' as its deployment framework. This commit changes it to 'static' to accurately reflect that it's a simple HTML, CSS, and JavaScript application.

This was determined by observing the lack of Hexo-specific files or configurations in the repository.